### PR TITLE
Add initial Conflict of Interest Policy

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "lint": {
+      "maximum-line-length": false
+    }
+  }
+}

--- a/CONFLICT_OF_INTEREST.md
+++ b/CONFLICT_OF_INTEREST.md
@@ -1,0 +1,10 @@
+---
+layout: page
+header: light
+title: Conflict of Interest Policy
+permalink: /our_mission/conflict_of_interest_policy/
+stylesheet: bylaws
+adopted_at:
+---
+
+We, the Directors of {{ site.title }}, resolve that no member of the Board of Directors or our member organizations shall participate in any discussion or vote on any matter in which he or she or a member of his or her immediate family has potential conflict of interest due to having material economic involvement regarding the matter being discussed. When such a situation presents itself, the director or member organization leader must announce his or her potential conflict, disqualify himself or herself, and be excused from the meeting until discussion is over on the matter involved. The President of the meeting is expected to make inquiry if such conflict appears to exist and the board member or member organization leader has not made it known.

--- a/CONFLICT_OF_INTEREST.md
+++ b/CONFLICT_OF_INTEREST.md
@@ -7,4 +7,114 @@ stylesheet: bylaws
 adopted_at:
 ---
 
-We, the Directors of {{ site.title }}, resolve that no member of the Board of Directors or our member organizations shall participate in any discussion or vote on any matter in which he or she or a member of his or her immediate family has potential conflict of interest due to having material economic involvement regarding the matter being discussed. When such a situation presents itself, the director or member organization leader must announce his or her potential conflict, disqualify himself or herself, and be excused from the meeting until discussion is over on the matter involved. The President of the meeting is expected to make inquiry if such conflict appears to exist and the board member or member organization leader has not made it known.
+<!-- lint disable no-multiple-toplevel-headings -->
+
+> Source: [https://www.irs.gov/pub/irs-pdf/i1023.pdf#page=25]()
+
+# Article I
+
+## Purpose
+
+### 1.01 - Purpose
+
+The purpose of the conflict of interest policy is to protect this tax-exempt organization’s (Organization) interest when it is contemplating entering into a transaction or arrangement that might benefit the private interest of an officer or director of the Organization or might result in a possible excess benefit transaction. This policy is intended to supplement but not replace any applicable state and federal laws governing conflict of interest applicable to nonprofit and charitable organizations.
+
+# Article II
+
+## Definitions
+
+### 2.01 - Interested Person
+
+Any director, principal officer, or member of a committee with governing board delegated powers, who has a direct or indirect financial interest, as defined below, is an interested person.
+
+### 2.02 - Financial Interest
+
+A person has a financial interest if the person has, directly or indirectly, through business, investment, or family:
+
+1.  An ownership or investment interest in any entity with which the Organization has a transaction or arrangement,
+2.  A compensation arrangement with the Organization or with any entity or individual with which the Organization has a transaction or arrangement, or
+3.  A potential ownership or investment interest in, or compensation arrangement with, any entity or individual with which the Organization is negotiating a transaction or arrangement.
+
+Compensation includes direct and indirect remuneration as well as gifts or favors that are not insubstantial.
+
+A financial interest is not necessarily a conflict of interest. Under [Article III, Section 2][a3s02], a person who has a financial interest may have a conflict of interest only if the appropriate governing board or committee decides that a conflict of interest exists.
+
+# Article III
+
+## Procedures
+
+### 3.01 - Duty to Disclose
+
+In connection with any actual or possible conflict of interest, an interested person must disclose the existence of the financial interest and be given the opportunity to disclose all material facts to the directors and members of committees with governing board delegated powers considering the proposed transaction or arrangement.
+
+### 3.02 - Determining Whether a Conflict of Interest Exists
+
+After disclosure of the financial interest and all material facts, and after any discussion with the interested person, he/she shall leave the governing board or committee meeting while the determination of a conflict of interest is discussed and voted upon. The remaining board or committee members shall decide if a conflict of interest exists.
+
+### 3.03 - Procedures for Addressing the Conflict of Interest
+
+1.  An interested person may make a presentation at the governing board or committee meeting, but after the presentation, he/she shall leave the meeting during the discussion of, and the vote on, the transaction or arrangement involving the possible conflict of interest.
+2.  The chairperson of the governing board or committee shall, if appropriate, appoint a disinterested person or committee to investigate alternatives to the proposed transaction or arrangement.
+3.  After exercising due diligence, the governing board or committee shall determine whether the Organization can obtain with reasonable efforts a more advantageous transaction or arrangement from a person or entity that would not give rise to a conflict of interest.
+4.  If a more advantageous transaction or arrangement is not reasonably possible under circumstances not producing a conflict of interest, the governing board or committee shall determine by a majority vote of the disinterested directors whether the transaction or arrangement is in the Organization’s best interest, for its own benefit, and whether it is fair and reasonable. In conformity with the above determination it shall make its decision as to whether to enter into the transaction or arrangement.
+
+### 3.04 - Violations of the Conflicts of Interest Policy
+
+1.  If the governing board or committee has reasonable cause to believe a member has failed to disclose actual or possible conflicts of interest, it shall inform the member of the basis for such belief and afford the member an opportunity to explain the alleged failure to disclose.
+2.  If, after hearing the member’s response and after making further investigation as warranted by the circumstances, the governing board or committee determines the member has failed to disclose an actual or possible conflict of interest, it shall take appropriate disciplinary and corrective action.
+
+# Article IV
+
+## Records of Proceedings
+
+### 4.01 - Records of Proceedings
+
+The minutes of the governing board and all committees with board delegated powers shall contain:
+
+1.  The names of the persons who disclosed or otherwise were found to have a financial interest in connection with an actual or possible conflict of interest, the nature of the financial interest, any action taken to determine whether a conflict of interest was present, and the governing board’s or committee’s decision as to whether a conflict of interest in fact existed.
+2.  The names of the persons who were present for discussions and votes relating to the transaction or arrangement, the content of the discussion, including any alternatives to the proposed transaction or arrangement, and a record of any votes taken in connection with the proceedings.
+
+# Article V
+
+## Compensation
+
+### 5.01 - Compensation
+
+1.  A voting member of the governing board who receives compensation, directly or indirectly, from the Organization for services is precluded from voting on matters pertaining to that member’s compensation.
+2.  A voting member of any committee whose jurisdiction includes compensation matters and who receives compensation, directly or indirectly, from the Organization for services is precluded from voting on matters pertaining to that member’s compensation.
+3.  No voting member of the governing board or any committee whose jurisdiction includes compensation matters and who receives compensation, directly or indirectly, from the Organization, either individually or collectively, is prohibited from providing information to any committee regarding compensation.
+
+# Article VI
+
+## Annual Statements
+
+### 6.01 - Annual Statements
+
+Each director, principal officer and member of a committee with governing board delegated powers shall annually sign a statement which affirms such person:
+
+1.  Has received a copy of the conflicts of interest policy,
+2.  Has read and understands the policy,
+3.  Has agreed to comply with the policy, and
+4.  Understands the Organization is charitable and in order to maintain its federal tax exemption it must engage primarily in activities which accomplish one or more of its tax-exempt purposes.
+
+# Article VII
+
+## Periodic Reviews
+
+### 7.01 - Periodic Reviews
+
+To ensure the Organization operates in a manner consistent with charitable purposes and does not engage in activities that could jeopardize its tax-exempt status, periodic reviews shall be conducted. The periodic reviews shall, at a minimum, include the following subjects:
+
+1.  Whether compensation arrangements and benefits are reasonable, based on competent survey information, and the result of arm’s length bargaining.
+2.  Whether partnerships, joint ventures, and arrangements with management organizations conform to the Organization’s written policies, are properly recorded, reflect reasonable investment or payments for goods and services, further charitable purposes and do not result in inurement, impermissible private benefit or in an excess benefit transaction.
+
+# Article VIII
+
+## Use of Outside Experts
+
+### 8.01 - Use of Outside Experts
+
+When conducting the periodic reviews as provided for in [Article VII][a7], the Organization may, but need not, use outside advisors. If outside experts are used, their use shall not relieve the governing board of its responsibility for ensuring periodic reviews are conducted.
+
+[a3s02]: #determining-whether-a-conflict-of-interest-exists "Article 3, Section 2"
+[a7]: #article-vii "Article VII"


### PR DESCRIPTION
I based this copy off of an example from http://www.idealist.org/info/Nonprofits/Gov5 with the inclusion of ensuring that member organization leaders are also included in the Conflict of Interest policy. We'll likely want to ensure that they sign a document stating that they've read and agree to this policy.

This closes #30 
